### PR TITLE
Update links / menu

### DIFF
--- a/html/common/footer.php
+++ b/html/common/footer.php
@@ -5,7 +5,7 @@
             <div class="uu-footer-1">
                 <h2>Where We Are</h2>
                 <p>
-                    INSCC Building (<a target="_blank" href="http://www.map.utah.edu/index.html?find=0019">map</a>)
+                    INSCC Building (<a target="_blank" href="https://www.map.utah.edu/index.html?find=0019">map</a>)
                     <br/>
                     3rd floor
                     <br/>
@@ -17,7 +17,7 @@
                 </p>
                 <p>
                     &copy; 2020
-                    <a href="http://www.utah.edu">The University of Utah</a>
+                    <a href="https://www.utah.edu">The University of Utah</a>
                 </p>
             </div>
             <!-- END FOOTER AREA 1 -->
@@ -27,16 +27,16 @@
                 <h2>Other Links</h2>
                 <ul>
                     <li>
-                        <a href="http://www.utah.edu/nondiscrimination/">Nondiscrimination &amp; Accessibility</a>
+                        <a href="https://www.utah.edu/nondiscrimination/">Nondiscrimination &amp; Accessibility</a>
                     </li>
                     <li>
-                        <a href="http://www.utah.edu/disclaimer/">Disclaimer</a>
+                        <a href="https://www.utah.edu/disclaimer/">Disclaimer</a>
                     </li>
                     <li>
-                        <a href="http://www.utah.edu/privacy/">Privacy</a>
+                        <a href="https://www.utah.edu/privacy/">Privacy</a>
                     </li>
                     <li>
-                        <a href="http://www.utah.edu/credits.php">Credits &amp; Attributions</a>
+                        <a href="https://www.utah.edu/credits-v2.php">Credits &amp; Attributions</a>
                     </li>
                     <li>
                         <span id="directedit"></span>
@@ -58,10 +58,10 @@
                             <a class="umail-link" title="U-Mail" href="https://www.umail.utah.edu/">U-Mail</a>
                         </li>
                         <li>
-                            <a class="facebook-link" title="facebook" href="http://www.facebook.com/universityofutah">facebook</a>
+                            <a class="facebook-link" title="facebook" href="https://www.facebook.com/universityofutah">facebook</a>
                         </li>
                         <li>
-                            <a class="twitter-link" title="twitter" href="http://twitter.com/uutah">twitter</a>
+                            <a class="twitter-link" title="twitter" href="https://twitter.com/uutah">twitter</a>
                         </li>
                     </ul>
                 </div>
@@ -72,7 +72,7 @@
             <div class="uu-footer-4">
 
                 <div class="footer-logo">
-                    <a href="http://imagineu.utah.edu/">
+                    <a href="https://imagineu.utah.edu/">
                         <img src="//templates.utah.edu/_main-v2/_images/footer/imagine_u.png" alt="Imagine U: The University of Utah"/>
                     </a>
                 </div>

--- a/html/common/header.php
+++ b/html/common/header.php
@@ -27,168 +27,77 @@
             <div class="collapse navbar-collapse" id="top-nav">
                 <ul class="nav navbar-nav navbar-right">
                     <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">News</a>
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Astro Group</a>
                         <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/news/index.php">News</a>
-                            </li>
-                            <li>
-                                <a title="COVID-19 Information" href="https://www.physics.utah.edu/covid/">COVID-19</a>
-                            </li>
+                            <li><a href="../overview/">Overview</a></li>
+                            <li><a href="../research/">Research</a></li>
+                            <li><a href="../graduate/">Graduate Program</a></li>
+                            <li><a href="../undergraduate/">Undergraduate Program</a></li>
+                            <li><a href="../people/">People</a></li>
+                            <li><a href="../computing/">Computing Resources</a></li>
+                            <li><a href="https://web.physics.utah.edu/weo">Willard Eccles Observatory</a></li>
+                            <li><a href="https://observatory.astro.utah.edu/">South Physics Observatory</a></li>
                         </ul>
                     </li>
                     <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Students</a>
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Department</a>
                         <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/courses/index.php">Courses</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/undergraduate-program/index.php">Undergraduates</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/graduate-program/index.php">Graduate Program</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/">Research</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/undergraduate-program/majors-emphases-minors.php">MAJORS, EMPHASES, AND MINORS</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/undergraduate-program/advising.php">ACADEMIC ADVISING</a>
-                            </li>
+                            <li><a href="https://www.physics.utah.edu/employment/">Employment</a></li>
+                            <li><a href="https://www.physics.utah.edu/inclusion/">Equity, Diversity and Inclusion</a></li>
+                            <li><a href="https://www.physics.utah.edu//directory/">Directory</a></li>
+                            <li><a href="https://www.physics.utah.edu/safety/">Safety</a></li>
+                            <li><a href="https://www.physics.utah.edu/secure/internal/">Internal</a></li>
+                        </ul>
+                    </li>
+                    <li class="dropdown ">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Graduate</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="https://www.physics.utah.edu/graduate-programs/">Graduate Program Overview</a></li>
+                            <li><a href="https://www.physics.utah.edu/prospective-graduates/">Prospective Grad Students</a>
+                            <li><a href="https://www.physics.utah.edu/prospective-graduates/application-guidance/">Application Guidance</a></li>
+                            <li><a href="https://www.physics.utah.edu/prospective-graduates/graduate-faq/">Graduate FAQ</a></li>
+                            <li><a href="https://www.physics.utah.edu/prospective-graduates/how-to-apply/">How to Apply</a></li>
+                        </ul>
+                    </li>
+                    <li class="dropdown ">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Undergraduate</a>
+                        <ul class="dropdown-menu">
+                        <li><a href="https://www.physics.utah.edu/undergraduate-program/">Undergraduate Program Overview</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/academic-advising/">Academic Advising</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/campus-resources/">Campus Resources</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/career-resources/">Career Resources</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/honors-program/">Honors Program</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/majors-emphases-minors/">Majors, Emphases &amp; Minors</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/permissions-codes-transfer-evaluations/">Permissions Codes &amp; Transfer Evaluations</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/scholarships/">Scholarships</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/student-involvement-employment/">Student Involvement &amp; Employment</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/tutoring-resources/">Tutoring Resources</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/undergraduate-faq/">Undergraduate FAQ</a></li>
+                            <li><a href="https://www.physics.utah.edu/wp-content/uploads/sites/65/2021/07/UndergradHandbook.pdf">Undergraduate Handbook</a></li>
+                            <li><a href="https://www.physics.utah.edu/undergraduate-program/undergraduate-research/">Undergraduate Research</a></li>
                         </ul>
                     </li>
                     <li class="dropdown ">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Research</a>
                         <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/">Home</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/astronomy-astrophysics.php">Astro Group</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/biophysics.php">Biophysics</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/condensed-matter/index.php">Condensed Matter</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/cosmic-rays.php">Cosmic Rays</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/particle-theory.php">Particle Physics</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/education.php">Physics Education Research</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/centers-institutes.php">Centers &amp; Institutes</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/reu-opportunities.php">REU Opportunities</a>
-                            </li>
+                            <li><a href="https://www.physics.utah.edu/research/">Research Overview</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/astronomy/">Astronomy</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/biophysics/">Biophysics</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/condensed-matter-physics/">Condensed Matter Physics</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/astroparticle-physics/">Astroparticle Physics</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/high-energy-physics/">High Energy Physics</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/physics-education-research/">Physics Education Research</a></li>
+                            <li><a href="https://www.physics.utah.edu/research/the-science-research-initiative/">The Science Research Initiative</a></li>
                         </ul>
                     </li>
                     <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Events</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/events/index.php">SEMINARS AND EVENTS</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/for-visitors/index.php">For Visitors</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/for-the-community/index.php">For the Community</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/conferences/">Conferences &amp; Workshops</a>
-                            </li>
-                        </ul>
+                        <a href="https://www.physics.utah.edu/reu-opportunities/">REU Opportunities</a>
                     </li>
                     <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Directory</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/people/index.php">Everyone</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/people/all-faculty.php">Faculty</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/people/staff.php">Staff</a>
-                            </li>
-                        </ul>
+                        <a href="https://www.physics.utah.edu/news-events/">News &amp; Events</a>
                     </li>
                     <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Resources</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/safety/">Safety</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/facilities/index.php">Facilities</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/computing/index.php">Computing</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/centers-institutes.php">Centers &amp; Institutes</a>
-                            </li>
-                            <li>
-                                <a title="COVID-19 Information" href="https://www.physics.utah.edu/covid/">COVID-19</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Internal</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/internal/index.php">Internal</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/accounting/index.php">Accounting</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/employment/index.php">Employment</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">About</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/about-us/index.php">About Us</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/newsletter/index.php">Newsletter</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/research/index.php">Research</a>
-                            </li>
-                            <li>
-                                <a href="https://www.physics.utah.edu/contact-us.php">Contact Us</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Inclusion</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://www.physics.utah.edu/equity-inclusion/index.php">Inclusion</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="dropdown ">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Giving</a>
-                        <ul class="dropdown-menu">
-                            <li>
-                                <a href="https://umarket.utah.edu/ugive/level4.php?catid=100" target="_blank">Giving</a>
-                            </li>
-                        </ul>
+                        <a href="https://umarket.utah.edu/ugive/level4.php?catid=100">Giving</a>
                     </li>
                 </ul>
             </div>

--- a/html/common/submenu.php
+++ b/html/common/submenu.php
@@ -7,40 +7,40 @@
                 </div>
                 <h3 style="color: #955;">Astro Group</h3>
                 <ul>
-                    <li class="">
+                    <li>
                         <a href="../overview/">Overview</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a href="../research/">Research</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a href="../graduate/">Graduate Program</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a href="../undergraduate/">Undergraduate Program</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a href="../people/">People</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a href="../computing/">Computing Resources</a>
                     </li>
-                    <li class="">
-                        <a target="_blank" href="http://www.physics.utah.edu/weo">Willard Eccles Observatory</a>
+                    <li>
+                        <a target="_blank" href="https://web.physics.utah.edu/weo">Willard Eccles Observatory</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a target="_blank" href="https://observatory.astro.utah.edu/">South Physics Observatory (on campus)</a>
                     </li>
                 </ul>
                 <h4 style="color: #955;">Events</h4>
                 <ul>
-                    <li class="">
+                    <li>
                         <a target="_blank" href="../events/">HEAP Seminar</a>
                     </li>
-                    <li class="">
-                        <a target="_blank" href="http://www.physics.utah.edu/events/">Colloquium (Calendar)</a>
+                    <li>
+                        <a target="_blank" href="https://www.physics.utah.edu/events/">Colloquium (Calendar)</a>
                     </li>
-                    <li class="">
+                    <li>
                         <a target="_blank" href="https://www.benty-fields.com/">Astrocoffee (Benty Fields)</a>
                     </li>
                 </ul>

--- a/html/events/functions.php
+++ b/html/events/functions.php
@@ -1,6 +1,6 @@
 <?php
     function physics_heap() {
-        $url = 'http://www.physics.utah.edu/~heap/schedule.shtml';
+        $url = 'https://web.physics.utah.edu/~heap/schedule.shtml';
         $header = get_web_page( $url );
         echo $header['content'];
     }

--- a/html/events/index.php
+++ b/html/events/index.php
@@ -20,9 +20,9 @@
                 <div class="uu-main-top row" id="uu-skip-target">
                     <div class="uu-top-content">
                         <h1 class="page-title">Department Events</h1>
-                         <a target="_physics" href="https://www.physics.utah.edu/events/index.php">Click here for this year's Physics Department Event Calendar</a>
+                         <a target="_physics" href="https://www.physics.utah.edu/events/">Click here for this year's Physics Department Event Calendar</a>
                         <h1 class="page-title">High Energy Astrophysics (HEAP)</h1>
-                         <a target="_heap" href="https://www.physics.utah.edu/~heap">Click here for this year's HEAP schedule</a>
+                         <a target="_heap" href="https://web.physics.utah.edu/~heap/">Click here for this year's HEAP schedule</a>
                     </div>
                 </div>
             </div>

--- a/html/graduate/index.php
+++ b/html/graduate/index.php
@@ -36,7 +36,7 @@
                                 This page provides some resources for you if you are currently
                                 a Ph.D. student or are interested in becoming one:
                                 <ul>
-                                    <li><a href="http://www.physics.utah.edu/graduate-program">Departmental Graduate information</a></li>
+                                    <li><a href="https://www.physics.utah.edu/graduate-programs/">Departmental Graduate information</a></li>
                                 </ul>
                             </p>
                         </div>

--- a/html/research/index.php
+++ b/html/research/index.php
@@ -34,7 +34,7 @@
                             helps form the clumps, while another (dark energy) is starting
                             to drive an accelerated expansion of these clumps away from each
                             other. A main goal is to characterize the properties and behavior of both dark matter and dark energy.
-                            [<a href="http://www.physics.utah.edu/~joelbrownstein/">Brownstein</a>, <a href="http://www.physics.utah.edu/~kdawson/">Dawson</a>, <a href="http://www.astro.utah.edu/~wik/">Wik</a>, <a href="http://www.astro.utah.edu/~zhengzheng/">Zheng</a>]
+                            [<a href="https://web.physics.utah.edu/~joelbrownstein/">Brownstein</a>, <a href="https://web.physics.utah.edu/~kdawson/">Dawson</a>, <a href="https://yymao.github.io/">Mao</a>, <a href="http://www.astro.utah.edu/~wik/">Wik</a>, <a href="https://www.astro.utah.edu/~zhengzheng/">Zheng</a>]
                             <br>&nbsp;
                             <br>
 
@@ -42,8 +42,8 @@
                             Milky Way, can contain hundreds to hundreds-of-billions of stars (give or take!), as well as
                             clouds of gas and dust, supermassive (and stellar mass) black holes, and dark matter. We look to see how galaxies were assembled and
                             how they interact with each other, giving clues about the formation of
-                            stars, the chemical enrichment of the Universe, and the nature of dark matter. 
-                            [<a href="http://www.physics.utah.edu/~joelbrownstein/">Brownstein</a>, <a href="http://www.physics.utah.edu/~aseth/">Seth</a>, <a href="http://www.physics.utah.edu/~zasowski/">Zasowski</a>, <a href="http://www.astro.utah.edu/~zhengzheng/">Zheng</a>]
+                            stars, the chemical enrichment of the Universe, and the nature of dark matter.
+                            [<a href="https://web.physics.utah.edu/~joelbrownstein/">Brownstein</a>, <a href="https://yymao.github.io/">Mao</a>, <a href="https://web.physics.utah.edu/~aseth/">Seth</a>, <a href="https://web.physics.utah.edu/~zasowski/">Zasowski</a>, <a href="https://www.astro.utah.edu/~zhengzheng/">Zheng</a>]
                             <br>&nbsp;
                             <br>
 
@@ -53,7 +53,7 @@
                             stars packed into a region of space smaller than our solar system.
                             We look at how these objects grow and influence the growth of
                             their host galaxies. Their origin remains a mystery....
-                            [<a href="http://www.physics.utah.edu/~aseth/">Seth</a>, <a href="http://www.physics.utah.edu/~bromley/">Bromley</a>, <a href="http://www.astro.utah.edu/~wik/">Wik</a>]
+                            [<a href="https://web.physics.utah.edu/~aseth/">Seth</a>, <a href="https://web.physics.utah.edu/~bromley/">Bromley</a>, <a href="https://web.astro.utah.edu/~wik/">Wik</a>]
                             <br>&nbsp;
                             <br>
 
@@ -63,9 +63,9 @@
                             By studying how these elements are spread across
                             different populations of stars in the Milky Way Galaxy,
                             we can understand the origin of the periodic table, including carbon, oxygen, and other
-                            elements necessary for life on Earth. Spectroscopy also tells us about how the stars are moving, 
-                            how old they are, and other properties that let us understand how the Milky Way formed and has changed over time.  
-                            [<a href="http://www.physics.utah.edu/~aseth/">Seth</a>, <a href="http://www.physics.utah.edu/~zasowski/">Zasowski</a>]
+                            elements necessary for life on Earth. Spectroscopy also tells us about how the stars are moving,
+                            how old they are, and other properties that let us understand how the Milky Way formed and has changed over time.
+                            [<a href="https://web.physics.utah.edu/~aseth/">Seth</a>, <a href="https://web.physics.utah.edu/~zasowski/">Zasowski</a>]
                             <br>&nbsp;
                             <br>
 
@@ -78,8 +78,8 @@
                             may reveal itself in interactions that can lead to
                             showers of high energy particles. So far there
                             have been only tentative hints of detections. Thus,
-                            the search continues. 
-                            [<a href="http://www.physics.utah.edu/~joelbrownstein/">Brownstein</a>, <a href="http://faculty.utah.edu/u0410334-PAOLO_GONDOLO/biography/index.hml">Gondolo</a>, <a href="http://www.physics.utah.edu/~sandick/">Sandick</a>, <a href="http://www.astro.utah.edu/~wik/">Wik</a>, <a href="http://www.physics.utah.edu/~zhaoyue/">Zhao</a>]
+                            the search continues.
+                            [<a href="https://web.physics.utah.edu/~joelbrownstein/">Brownstein</a>, <a href="https://faculty.utah.edu/u0410334-PAOLO_GONDOLO/">Gondolo</a>, <a href="https://yymao.github.io/">Mao</a>, <a href="https://web.physics.utah.edu/~sandick/">Sandick</a>, <a href="https://www.astro.utah.edu/~wik/">Wik</a>, <a href="https://web.physics.utah.edu/~zhaoyue/">Zhao</a>]
                             <br>&nbsp;
                             <br>
 
@@ -90,7 +90,7 @@
                             to thousands seen around other stars. We are working to understand
                             the mechanisms at play in the formation of planets, in particular of
                             rocky planets like our own Earth. Is this process universal, and
-                            do we have company in the Universe? [<a href="http://www.physics.utah.edu/~bromley/">Bromley</a>]
+                            do we have company in the Universe? [<a href="https://web.physics.utah.edu/~bromley/">Bromley</a>]
 
                             </ul>
                         </div>

--- a/html/undergraduate/index.php
+++ b/html/undergraduate/index.php
@@ -38,17 +38,17 @@
                                       <a href="https://catalog.utah.edu/#/courses?group=Physics%20%26%20Astronomy">here.</a></li>
 
                                     <li> The
-                                    <a href="https://www.physics.utah.edu/_documents/UndergradHandbook2020.pdf">Department Undergraduate Handbook</a>, which has both the degree requirements for the minor and astrophysics emphasis.)</li>
+                                    <a href="https://www.physics.utah.edu/wp-content/uploads/sites/65/2021/07/UndergradHandbook.pdf">Department Undergraduate Handbook</a>, which has both the degree requirements for the minor and astrophysics emphasis.)</li>
 
                                     <li> Note that PHYS/ASTR 3070 is the "gateway" course to our astronomy course offerings -- this is offered each fall; other courses may be offered only every two years.  Please talk to us if you need help planning your major.</li>
                                 </ul>
 
                             </p>
-                        
+
                             <h3>Getting Undergraduate Research</h3>
-                        
+
                             <p>Watch this space for a guide on how to get started on choosing a research topic in Astronomy (coming soon).</p>
-                        
+
                             <ul>
                                 <li><a target="_physics" href="https://www.physics.utah.edu/reu-opportunities/">Research Experiences for Undergrads (REU)</a>:  The application deadline for this program is 1/31/2022.</li>
                             </ul>


### PR DESCRIPTION
Lots of the links are no longer working due to the update of the physics website. This PR attempts to fix most, if not all, of them. 

Basically I copy the new menu from the updated physics website, but fit them in the current template (I did not attempt to change the template). I also fixed a few other broken links here and there. 